### PR TITLE
ci: add minimal CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+﻿name: CI
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "ok"


### PR DESCRIPTION
Adds a minimal passing CI workflow (checkout + echo) to enable branch protection gates.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author