### PR TITLE
Switch registry to new subfolder modules; fix architecture docs corruption

### DIFF
--- a/docs/augment_reports/architecture/tools_reorg_proposal_2025-09-20.md
+++ b/docs/augment_reports/architecture/tools_reorg_proposal_2025-09-20.md
@@ -1,7 +1,7 @@
-## Tools Reorganization Proposal (202509020)
+## Tools Reorganization Proposal (2025-09-20)
 
 ### YES/NO Summary
-YES 4 Proposed folderization and universal UI plan provided (no code moves performed yet).
+YES — Proposed folderization and universal UI plan provided (no code moves performed yet).
 
 ### Design goals
 - Clarity: entry-point tools separated from helpers and provider-specific scripts
@@ -36,29 +36,29 @@ Notes:
 - We can either keep current classes in place and add thin import shims under entrypoints/ to avoid breaking imports, or move files and update TOOL_MAP to point to new module paths.
 - Registry (TOOL_MAP) remains the single exposure gate. Visibility map (core/advanced/hidden) continues to control menu size.
 
-### Mapping: current file 3	o proposed location
-- analyze.py 3	o workflows/analyze.py
-- codereview.py 3	o workflows/codereview.py
-- debug.py 3	o workflows/debug.py
-- precommit.py 3	o workflows/precommit.py
-- refactor.py 3	o workflows/refactor.py
-- secaudit.py 3	o workflows/secaudit.py
-- testgen.py 3	o workflows/testgen.py
-- planner.py 3	o workflows/planner.py
-- consensus.py 3	o workflows/consensus.py
-- thinkdeep.py 3	o workflows/thinkdeep.py
-- tracer.py 3	o workflows/tracer.py
-- docgen.py 3	o workflows/docgen.py
-- chat.py 3	o entrypoints/chat.py (optional shim) or workflows/chat.py
-- listmodels.py 3	o capabilities/listmodels.py
-- provider_capabilities.py 3	o capabilities/provider_capabilities.py
-- autopilot.py, orchestrate_auto.py, browse_orchestrator.py 3	o orchestrators/
-- toolcall_log_tail.py, health.py, status.py, diagnose_ws_stack.py, ws_daemon_smoke.py 3	o diagnostics/
-- stream_demo.py, streaming_demo_tool.py, streaming_smoke_tool.py 3	o streaming/
-- kimi_upload.py, kimi_tools_chat.py, kimi_embeddings.py, kimi_files_cleanup.py 3	o providers/kimi/
-- glm_files.py, glm_agents.py, glm_files_cleanup.py 3	o providers/glm/
-- recommend.py 3	o (defer or incubate under workflows/ or orchestrators/ when registered)
-- selfcheck.py 3	o diagnostics/ (keep hidden unless explicitly enabled)
+### Mapping: current file -> proposed location
+- analyze.py -> workflows/analyze.py
+- codereview.py -> workflows/codereview.py
+- debug.py -> workflows/debug.py
+- precommit.py -> workflows/precommit.py
+- refactor.py -> workflows/refactor.py
+- secaudit.py -> workflows/secaudit.py
+- testgen.py -> workflows/testgen.py
+- planner.py -> workflows/planner.py
+- consensus.py -> workflows/consensus.py
+- thinkdeep.py -> workflows/thinkdeep.py
+- tracer.py -> workflows/tracer.py
+- docgen.py -> workflows/docgen.py
+- chat.py -> entrypoints/chat.py (optional shim) or workflows/chat.py
+- listmodels.py -> capabilities/listmodels.py
+- provider_capabilities.py -> capabilities/provider_capabilities.py
+- autopilot.py, orchestrate_auto.py, browse_orchestrator.py -> orchestrators/
+- toolcall_log_tail.py, health.py, status.py, diagnose_ws_stack.py, ws_daemon_smoke.py -> diagnostics/
+- stream_demo.py, streaming_demo_tool.py, streaming_smoke_tool.py -> streaming/
+- kimi_upload.py, kimi_tools_chat.py, kimi_embeddings.py, kimi_files_cleanup.py -> providers/kimi/
+- glm_files.py, glm_agents.py, glm_files_cleanup.py -> providers/glm/
+- recommend.py -> (defer or incubate under workflows/ or orchestrators/ when registered)
+- selfcheck.py -> diagnostics/ (keep hidden unless explicitly enabled)
 
 ### Universal UI summary (server-level)
 Problem: Only ThinkDeep emits ui_summary today; we want all tools to include a uniform UI block.
@@ -96,7 +96,7 @@ flowchart LR
    - Keep deprecation shims if needed
 4) Verification
    - list_tools, run smokes (chat GLM/Kimi, thinkdeep expert/non-expert), provider tools
-   - Ensure DIAGNOSTICS gating works and hidden tools don2t leak
+   - Ensure DIAGNOSTICS gating works and hidden tools don't leak
 5) Cleanup
    - Remove shims after a cooling period with green CI
 

--- a/docs/augment_reports/architecture/universal_ui_summary_2025-09-20.md
+++ b/docs/augment_reports/architecture/universal_ui_summary_2025-09-20.md
@@ -1,7 +1,7 @@
-## Universal UI Summary d Architecture (2025d09d20)
+## Universal UI Summary Architecture (2025-09-20)
 
 ### YES/NO Summary
-YES d Designed a server-level UI wrapper (tool-agnostic) and GLM-4.5-flash manager parameters.
+YES — Designed a server-level UI wrapper (tool-agnostic) and GLM-4.5-flash manager parameters.
 
 ### Goals
 - Provide a consistent UI block for every tool response without changing each tool

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -17,55 +17,55 @@ from typing import Any, Dict
 TOOL_MAP: Dict[str, tuple[str, str]] = {
     # Core
     "chat": ("tools.chat", "ChatTool"),
-    "analyze": ("tools.analyze", "AnalyzeTool"),
-    "debug": ("tools.debug", "DebugIssueTool"),
-    "codereview": ("tools.codereview", "CodeReviewTool"),
-    "refactor": ("tools.refactor", "RefactorTool"),
-    "secaudit": ("tools.secaudit", "SecauditTool"),
-    "planner": ("tools.planner", "PlannerTool"),
-    "tracer": ("tools.tracer", "TracerTool"),
-    "testgen": ("tools.testgen", "TestGenTool"),
-    "consensus": ("tools.consensus", "ConsensusTool"),
-    "thinkdeep": ("tools.thinkdeep", "ThinkDeepTool"),
-    "docgen": ("tools.docgen", "DocgenTool"),
+    "analyze": ("tools.workflows.analyze", "AnalyzeTool"),
+    "debug": ("tools.workflows.debug", "DebugIssueTool"),
+    "codereview": ("tools.workflows.codereview", "CodeReviewTool"),
+    "refactor": ("tools.workflows.refactor", "RefactorTool"),
+    "secaudit": ("tools.workflows.secaudit", "SecauditTool"),
+    "planner": ("tools.workflows.planner", "PlannerTool"),
+    "tracer": ("tools.workflows.tracer", "TracerTool"),
+    "testgen": ("tools.workflows.testgen", "TestGenTool"),
+    "consensus": ("tools.workflows.consensus", "ConsensusTool"),
+    "thinkdeep": ("tools.workflows.thinkdeep", "ThinkDeepTool"),
+    "docgen": ("tools.workflows.docgen", "DocgenTool"),
     # Utilities (always on)
-    "version": ("tools.version", "VersionTool"),
-    "listmodels": ("tools.listmodels", "ListModelsTool"),
+    "version": ("tools.capabilities.version", "VersionTool"),
+    "listmodels": ("tools.capabilities.listmodels", "ListModelsTool"),
     "self-check": ("tools.selfcheck", "SelfCheckTool"),
     # Web tools removed: internet access disabled in production build
 
     # Precommit and Challenge utilities
-    "precommit": ("tools.precommit", "PrecommitTool"),
+    "precommit": ("tools.workflows.precommit", "PrecommitTool"),
     "challenge": ("tools.challenge", "ChallengeTool"),
     # Orchestrators (aliases map to autopilot)
-    "orchestrate_auto": ("tools.autopilot", "AutopilotTool"),
+    "orchestrate_auto": ("tools.orchestrators.autopilot", "AutopilotTool"),
     # Kimi utilities
-    "kimi_upload_and_extract": ("tools.kimi_upload", "KimiUploadAndExtractTool"),
-    "kimi_multi_file_chat": ("tools.kimi_upload", "KimiMultiFileChatTool"),
+    "kimi_upload_and_extract": ("tools.providers.kimi.kimi_upload", "KimiUploadAndExtractTool"),
+    "kimi_multi_file_chat": ("tools.providers.kimi.kimi_upload", "KimiMultiFileChatTool"),
     # GLM utilities
-    "glm_upload_file": ("tools.glm_files", "GLMUploadFileTool"),
-    "glm_multi_file_chat": ("tools.glm_files", "GLMMultiFileChatTool"),
+    "glm_upload_file": ("tools.providers.glm.glm_files", "GLMUploadFileTool"),
+    "glm_multi_file_chat": ("tools.providers.glm.glm_files", "GLMMultiFileChatTool"),
     # GLM Agent APIs
-    "glm_agent_chat": ("tools.glm_agents", "GLMAgentChatTool"),
-    "glm_agent_get_result": ("tools.glm_agents", "GLMAgentGetResultTool"),
-    "glm_agent_conversation": ("tools.glm_agents", "GLMAgentConversationTool"),
+    "glm_agent_chat": ("tools.providers.glm.glm_agents", "GLMAgentChatTool"),
+    "glm_agent_get_result": ("tools.providers.glm.glm_agents", "GLMAgentGetResultTool"),
+    "glm_agent_conversation": ("tools.providers.glm.glm_agents", "GLMAgentConversationTool"),
     # Kimi chat with tools/tool_choice
-    "kimi_chat_with_tools": ("tools.kimi_tools_chat", "KimiChatWithToolsTool"),
+    "kimi_chat_with_tools": ("tools.providers.kimi.kimi_tools_chat", "KimiChatWithToolsTool"),
     # Diagnostics
-    "provider_capabilities": ("tools.provider_capabilities", "ProviderCapabilitiesTool"),
+    "provider_capabilities": ("tools.capabilities.provider_capabilities", "ProviderCapabilitiesTool"),
     # Observability helpers
-    "toolcall_log_tail": ("tools.toolcall_log_tail", "ToolcallLogTail"),
+    "toolcall_log_tail": ("tools.diagnostics.toolcall_log_tail", "ToolcallLogTail"),
     "activity": ("tools.activity", "ActivityTool"),
     # Health
-    "health": ("tools.health", "HealthTool"),
+    "health": ("tools.diagnostics.health", "HealthTool"),
     # Status alias (friendly summary)
-    "status": ("tools.status", "StatusTool"),
+    "status": ("tools.diagnostics.status", "StatusTool"),
     # Autopilot orchestrator (opt-in)
-    "autopilot": ("tools.autopilot", "AutopilotTool"),
+    "autopilot": ("tools.orchestrators.autopilot", "AutopilotTool"),
     # Browse orchestrator (alias to autopilot)
-    "browse_orchestrator": ("tools.autopilot", "AutopilotTool"),
+    "browse_orchestrator": ("tools.orchestrators.autopilot", "AutopilotTool"),
     # Streaming demo (utility)
-    "stream_demo": ("tools.stream_demo", "StreamDemoTool"),
+    "stream_demo": ("tools.streaming.stream_demo", "StreamDemoTool"),
 
 }
 # Visibility map for tools: 'core' | 'advanced' | 'hidden'


### PR DESCRIPTION
This PR completes the registry step by pointing TOOL_MAP to the new non-destructive subfolder copies (workflows, providers, diagnostics, orchestrators, streaming, capabilities). It also fixes control-character corruption and validates Mermaid blocks in the architecture docs.

Notes
- No runtime behavior change expected: classes are identical copies, originals remain at root for now
- Universal UI wrapper is paused per request; this PR is limited to registry + doc fixes
- Follow-up: after a cooling period, replace top-level files with import shims or remove them if desired

Test plan
- list_tools should show same set; tool invocations resolve new module paths
- Docs render correctly and Mermaid blocks are valid
